### PR TITLE
Fix knex-mock-client usage

### DIFF
--- a/server/tests/users.test.ts
+++ b/server/tests/users.test.ts
@@ -1,21 +1,20 @@
 import app from "../src/app";
 import {agent as request} from "supertest";
-import {Knex} from "knex";
-import {createTracker, MockClient, Tracker} from 'knex-mock-client';
+import {createTracker, Tracker} from 'knex-mock-client';
 import {faker} from '@faker-js/faker';
+import { knex as db } from '../src/database/db';
 import {User} from "../src/users/user";
 
 jest.mock('../src/database/db', () => {
-    const knex = require('knex');
+    const Knex = require('knex');
+    const { MockClient } = require('knex-mock-client');
     return {
-        db: knex({client: MockClient}),
+        knex: Knex({client: MockClient}),
     };
 });
 
 describe("Test users APIs", () => {
     const baseURL = "/api/users"
-
-    let db: Knex;
     let tracker: Tracker;
 
     beforeAll(() => {


### PR DESCRIPTION
fix: align src/database/db export the same module in the mock
fix: move MockClient inside the module mock block